### PR TITLE
composer_installation コンテナを削除

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -10,27 +10,6 @@ services:
         depends_on:
             - php-container
 
-    composer_installation:
-        container_name: laravel-nyumon-composer-installation
-        image: composer
-        volumes:
-          - ./:/app
-        entrypoint:
-            - sh
-        command:
-            # .exec-onceというファイルがあったら実行しない
-            # 最初にコマンド実行がなされていたら、.exec-onceというファイルが作成されるようにしている
-            # .exec-onceがあるが、すでにcomposer installなどが実行されているケースもあるため、
-            # 注意すること。もし.exec-onceがあるのに、次のものが存在する場合は、何かしら個人で触った影響。
-            # 1. .env ファイルがある
-            # 2. vendorディレクトリがある(composer installが実行済みであるということ)
-            # 3. php artisan key:generateされている(.envファイルのAPP_KEY=のあとの文字がある場合はkey:generateが実行済みということ)
-            - -c
-            - |
-              [ -f ./.exec-once ] || {
-                cp .env.example .env && composer install --ignore-platform-reqs && php artisan key:generate && touch ./.exec-once
-              }
-
     yarn_installation:
         container_name: laravel-nyumon-yarn-installation
         image: node:22-bookworm
@@ -56,7 +35,6 @@ services:
         volumes:
             - ./:/var/www:cached
         depends_on:
-            - composer_installation
             - yarn_installation
         env_file:
             - .env

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,0 +1,8 @@
+<?php
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
+
+Route::get('/user', function (Request $request) {
+    return $request->user();
+})->middleware('auth:sanctum');

--- a/tests/Feature/LaravelNyumon/Station10/DiaryControllerTest.php
+++ b/tests/Feature/LaravelNyumon/Station10/DiaryControllerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature\LaravelNyumon\Station9;
+namespace Tests\Feature\LaravelNyumon\Station10;
 
 use Tests\TestCase;
 use PHPUnit\Framework\Attributes\Group;

--- a/tests/Feature/LaravelNyumon/Station9/DiaryControllerTest.php
+++ b/tests/Feature/LaravelNyumon/Station9/DiaryControllerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature\LaravelNyumon\Station10;
+namespace Tests\Feature\LaravelNyumon\Station9;
 
 use Tests\TestCase;
 use PHPUnit\Framework\Attributes\Group;


### PR DESCRIPTION
- composer コマンドの実行は手動で行うように変更したため、同じ処理を実施するコンテナは不要になった
- Station9 と Station10 を入れ替えた際にテストコードの namespace を変え忘れたため修正
- 設定時に composer install を通すため、api.php を最初から作っておく